### PR TITLE
Render Rich Text embedded assets

### DIFF
--- a/app/routes/case-study.$caseStudySlug.tsx
+++ b/app/routes/case-study.$caseStudySlug.tsx
@@ -1,12 +1,5 @@
-import {
-  BLOCKS,
-  INLINES,
-  type Block,
-  type Inline,
-} from "@contentful/rich-text-types"
 import { type DataFunctionArgs, json, type MetaFunction } from "@remix-run/node"
 import { useLoaderData } from "@remix-run/react"
-import { type ReactNode } from "react"
 import { getCaseStudies, getCaseStudyBySlug } from "~/models/case-study.server"
 import { CaseStudy } from "~/ui/templates/CaseStudy"
 import { invariantResponse } from "~/utils/invariant.server"
@@ -17,33 +10,6 @@ import { getSocialMetas } from "~/utils/seo"
 import type { SEOHandle } from "@nasa-gcn/remix-seo"
 import { Show500 } from "~/ui/templates/500"
 import { z } from "zod"
-
-export const richTextRenderOptions = {
-  renderNode: {
-    [INLINES.HYPERLINK]: (node: Block | Inline, children: ReactNode) => {
-      const { data } = node
-      const { uri } = data
-      return (
-        <a
-          className="text-primary underline dark:text-gray-400"
-          target="_blank"
-          rel="noreferrer"
-          href={uri}
-        >
-          {children}
-        </a>
-      )
-    },
-    [BLOCKS.PARAGRAPH]: (node: Block | Inline, children: ReactNode) => {
-      return (
-        <p className="mb-4 text-base leading-relaxed text-black">{children}</p>
-      )
-    },
-    [BLOCKS.HEADING_2]: (node: Block | Inline, children: ReactNode) => {
-      return <h2 className="mb-5 text-3xl dark:text-gray-200">{children}</h2>
-    },
-  },
-}
 
 export const loader = async ({ params }: DataFunctionArgs) => {
   const { caseStudySlug } = params

--- a/app/ui/templates/CaseStudy.tsx
+++ b/app/ui/templates/CaseStudy.tsx
@@ -63,9 +63,9 @@ function renderOptions(links: z.infer<typeof LinksSchema>) {
           <div className="my-6 w-full">
             <figure>
               <picture>
-                <source type="image/avif" srcSet={`${url}?fm=avif`} />
-                <source type="image/webp" srcSet={`${url}?fm=webp`} />
-                <source type="image/webp" srcSet={`${url}?fm=png`} />
+                <source type="image/avif" srcSet={`${url}?fm=avif&w=2000`} />
+                <source type="image/webp" srcSet={`${url}?fm=webp&w=2000`} />
+                <source type="image/webp" srcSet={`${url}?fm=png&w=2000`} />
                 <motion.img
                   src={url}
                   alt={title}

--- a/app/ui/templates/CaseStudy.tsx
+++ b/app/ui/templates/CaseStudy.tsx
@@ -1,10 +1,91 @@
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
-import { richTextRenderOptions } from "~/routes/case-study.$caseStudySlug"
 import { type CaseStudy } from "~/models/case-study.server"
 import Header from "~/ui/components/Header"
 import { motion, useReducedMotion } from "framer-motion"
+import type { Block, Inline } from "@contentful/rich-text-types"
+import { BLOCKS, INLINES } from "@contentful/rich-text-types"
+import type { z } from "zod"
+import type { ReactNode } from "react"
+import type {
+  AssetLinkSchema,
+  LinksSchema,
+} from "~/schemas/contentful-fields/rich-text.server"
 
 type CaseStudyProps = CaseStudy
+
+function renderOptions(links: z.infer<typeof LinksSchema>) {
+  // create an asset map
+  const assetMap = new Map<string, z.infer<typeof AssetLinkSchema>>()
+
+  // loop through the assets and add them to the map
+  for (const asset of links.assets.block) {
+    assetMap.set(asset.sys.id, asset)
+  }
+
+  return {
+    renderNode: {
+      [INLINES.HYPERLINK]: (node: Block | Inline, children: ReactNode) => {
+        const { data } = node
+        const { uri } = data
+        return (
+          <a
+            className="text-primary underline dark:text-gray-400"
+            target="_blank"
+            rel="noreferrer"
+            href={uri}
+          >
+            {children}
+          </a>
+        )
+      },
+      [BLOCKS.PARAGRAPH]: (_: Block | Inline, children: ReactNode) => {
+        return (
+          <p className="mb-4 text-base leading-relaxed text-black">
+            {children}
+          </p>
+        )
+      },
+      [BLOCKS.HEADING_2]: (_: Block | Inline, children: ReactNode) => {
+        return <h2 className="mb-5 text-3xl dark:text-gray-200">{children}</h2>
+      },
+      [BLOCKS.EMBEDDED_ASSET]: (node: Block | Inline) => {
+        const { data } = node
+        const { target } = data
+        const asset = assetMap.get(target.sys.id)
+
+        if (!asset) {
+          return null
+        }
+
+        const { title, description, url, width, height } = asset
+
+        return (
+          <div className="my-6 w-full">
+            <figure>
+              <picture>
+                <source type="image/avif" srcSet={`${url}?fm=avif`} />
+                <source type="image/webp" srcSet={`${url}?fm=webp`} />
+                <source type="image/webp" srcSet={`${url}?fm=png`} />
+                <motion.img
+                  src={url}
+                  alt={title}
+                  className="w-full overflow-hidden rounded-xl border"
+                  width={width}
+                  height={height}
+                />
+              </picture>
+              {description ? (
+                <figcaption className="bg-gray-100 p-4 text-center dark:bg-gray-800">
+                  {description}
+                </figcaption>
+              ) : null}
+            </figure>
+          </div>
+        )
+      },
+    },
+  }
+}
 
 export function CaseStudy({
   headline,
@@ -40,7 +121,10 @@ export function CaseStudy({
             {headline}
           </h1>
           {mainContent
-            ? documentToReactComponents(mainContent.json, richTextRenderOptions)
+            ? documentToReactComponents(
+                mainContent.json,
+                renderOptions(mainContent?.links),
+              )
             : null}
         </div>
       </main>

--- a/app/ui/templates/CaseStudy.tsx
+++ b/app/ui/templates/CaseStudy.tsx
@@ -13,6 +13,11 @@ import type {
 
 type CaseStudyProps = CaseStudy
 
+/**
+ * Render options for the rich text renderer and the linked assets
+ *
+ * @link https://www.contentful.com/developers/docs/concepts/rich-text/#rendering-the-rich-text-response-from-the-graphql-api-with-linked-assets-and-entries-on-the-front-end
+ */
 function renderOptions(links: z.infer<typeof LinksSchema>) {
   // create an asset map
   const assetMap = new Map<string, z.infer<typeof AssetLinkSchema>>()


### PR DESCRIPTION
The following updates have been made: 

- New schemas to model data for embedded assets
- Helper function for generated a schema with add-ons for the RichText field
   - It's possible not every server model needs to handle embedded images
- Updated query for `getCaseStudyBySlug()` to ensure the following:
   - The limit is set to one since we only ever need one case study at a time for the internal template
   - Retrieve any "links" which are the referenced assets objects needed to render the `<img>` properly

Instructions for testing:

1. Update your `.env` to connect to the `dev` environment
2. Go to `/case-study/homewise` to view a Case Study with an embedded image
3. Go to `/case-study/grid-alternatives` to view a Case Study with just text/paragraphs