### PR TITLE
Page routes handling

### DIFF
--- a/app/models/about.server.ts
+++ b/app/models/about.server.ts
@@ -80,70 +80,72 @@ export async function getAboutPage(id: string): Promise<AboutPage | null> {
   return validateWithSchema(AboutPageSchema, aboutPage)
 }
 
-export async function getAboutPages(
-  count: number = 10,
-): Promise<Array<AboutPage>> {
-  const query = `
-    query {
-        aboutPageCollection(limit: ${count}) {
-            items {
-                title
-                sectionsCollection {
-                    items {
-                        title
-                        mainContent {
-                            json
-                        }
-                        featuredImage {
-                            fileName
-                            url
-                            description
-                            width
-                            height
-                        }
-                        imagesCollection {
-                          items {
-                            fileName
-                            url
-                            width
-                            height
-                          }
-                        }
-                    }
-                }
-                featuredImage {
-                    fileName
-                    url
-                    description
-                    width
-                    height
-                }
-                seo {
-                  title
-                  excerpt
-                  image {
-                    fileName
-                    url
-                    description
-                    width
-                    height
-                  }
-                }
+const AboutPageBySlugQuery = `
+  query AboutPageBySlug($slug: String!) {
+    aboutPageCollection(where: {slug: $slug}, limit: 1) {
+      items {
+        title
+        sectionsCollection {
+          items {
+            title
+            mainContent {
+              json
             }
+            featuredImage {
+              fileName
+              url
+              description
+              width
+              height
+            }
+            imagesCollection {
+              items {
+                fileName
+                url
+                width
+                height
+              }
+            }
+          }
         }
-    }`
+        featuredImage {
+          fileName
+          url
+          description
+          width
+          height
+        }
+        seo {
+          title
+          excerpt
+          image {
+            fileName
+            url
+            description
+            width
+            height
+          }
+          keywords
+        }
+      }
+    }
+  }
+`
 
+export async function getAboutPageBySlug(
+  slug: string,
+): Promise<AboutPage | null> {
   const response = await typedFetchGraphQL<{
     aboutPageCollection: { items: Array<AboutPage> }
-  }>(query)
+  }>(AboutPageBySlugQuery, { slug })
 
   if (!response.data) {
-    console.error(`Error for About Page collection`, response.errors)
+    console.error(`Error for About Page with slug:${slug}`, response.errors)
 
-    return []
+    return null
   }
 
-  const aboutPages = response.data.aboutPageCollection.items
+  const aboutPage = response.data.aboutPageCollection.items[0]
 
-  return validateWithSchema(AboutPagesSchema, aboutPages)
+  return validateWithSchema(AboutPageSchema, aboutPage)
 }

--- a/app/models/case-studies.server.ts
+++ b/app/models/case-studies.server.ts
@@ -63,3 +63,60 @@ export async function getCaseStudiesPage(
 
   return validateWithSchema(CaseStudiesPageSchema, caseStudiesPage)
 }
+
+const CaseStudiesBySlugQuery = `
+  query CaseStudiesBySlug($slug: String!) {
+    caseStudiesCollection(where: {slug: $slug}, limit: 1) {
+      items {
+        id
+        title
+        headline
+        mainContent {
+          json
+        }
+        featuredImage {
+          fileName
+          url
+          description
+          width
+          height
+        }
+        seo {
+          title
+          excerpt
+          image {
+            fileName
+            url
+            description
+            width
+            height
+          }
+          keywords
+        }
+      }
+    }
+  }
+`
+
+export async function getCaseStudiesPageBySlug(
+  slug: string,
+): Promise<CaseStudies | null> {
+  const response = await typedFetchGraphQL<{
+    caseStudiesCollection: {
+      items: Array<CaseStudies>
+    }
+  }>(CaseStudiesBySlugQuery, { slug })
+
+  if (!response.data) {
+    console.error(
+      `Error for Case Studies Page with slug:${slug}`,
+      response.errors,
+    )
+
+    return null
+  }
+
+  const caseStudiesPage = response.data.caseStudiesCollection.items[0]
+
+  return validateWithSchema(CaseStudiesPageSchema, caseStudiesPage)
+}

--- a/app/models/landing-page.server.ts
+++ b/app/models/landing-page.server.ts
@@ -38,6 +38,7 @@ const SectionsDiscriminatedUnion = z.discriminatedUnion("__typename", [
 
 export const LandingPageSchema = z.object({
   title: z.string(),
+  slug: z.string(),
   sectionsCollection: z.object({
     items: z.array(SectionsDiscriminatedUnion),
   }),
@@ -51,6 +52,7 @@ export async function getLandingPage(id: string) {
     query {
         landingPage(id: "${id}") {
             title
+            slug
             sectionsCollection {
                 items {
                     __typename
@@ -250,6 +252,221 @@ export async function getLandingPage(id: string) {
   }
 
   const landingPage = response.data.landingPage
+
+  return validateWithSchema(LandingPageSchema, landingPage)
+}
+
+const LandingPageBySlugQuery = `
+    query LandingPageBySlug($slug: String!) {
+        landingPageCollection(where: { slug: $slug }, limit: 1) {
+            items {
+                title
+                slug
+                sectionsCollection {
+                    items {
+                        __typename
+                        ... on SectionHero {
+                            title
+                            mainContent {
+                                json
+                            }
+                            featuredImage {
+                                fileName
+                                url
+                                description
+                                width
+                                height
+                            }
+                        }
+                        ... on SectionTextMultiImageSplit {
+                            title
+                            mainContent {
+                                json
+                            }
+                            featuredImagesCollection {
+                                items {
+                                    fileName
+                                    url
+                                    width
+                                    height
+                                }
+                            }
+                        }
+                        ... on SectionTextImageSplit {
+                            title
+                            mainContent {
+                                json
+                            }
+                            featuredImage {
+                                fileName
+                                url
+                                width
+                                height
+                            }
+                        }
+                        ... on SectionBucketGrid {
+                            title
+                            headline
+                            mainContent {
+                                json
+                            }
+                            bucketsCollection {
+                                items {
+                                    title
+                                    bucketText {
+                                        json
+                                    }
+                                    bucketImage {
+                                        fileName
+                                        url
+                                        width
+                                        height
+                                    }
+                                }
+                            }
+                        }
+                        ... on SectionTextImage {
+                            title
+                            mainContent {
+                                json
+                            }
+                            featuredImage {
+                                fileName
+                                url
+                                width
+                                height
+                            }
+                        }
+                        ... on SectionEventsResources {
+                            title
+                            headlineEvents
+                            eventsCollection(limit: 3) {
+                                items {
+                                    title
+                                    slug
+                                    headline
+                                    datetime
+                                    location
+                                    excerpt {
+                                        json
+                                    }
+                                    mainContent {
+                                        json
+                                    }
+                                    seo {
+                                    title
+                                    excerpt
+                                    image {
+                                        fileName
+                                        url
+                                        description
+                                        width
+                                        height
+                                    }
+                                    keywords
+                                    }
+                                }
+                            }
+                            textEvents {
+                            json
+                            }
+                            headlineResources
+                            resourcesCollection(limit: 6) {
+                                items {
+                                    title
+                                    file {
+                                        fileName
+                                        url
+                                    }
+                                }
+                            }
+                            featuredImage {
+                                fileName
+                                url
+                                width
+                                height
+                            }
+                        }
+                        ... on SectionSocialMediaCta {
+                            title
+                            headline
+                            socialMediaLinksCollection {
+                                items {
+                                    platform
+                                    url
+                                }
+                            }
+                        }
+                        ... on SectionNewsPressReleases {
+                            title
+                            headline
+                            postsCollection(limit: 5) {
+                                items {
+                                    title
+                                    slug
+                                    date
+                                    headline
+                                    excerpt {
+                                        json
+                                    }
+                                    mainContent {
+                                        json
+                                    }
+                                    featuredImage {
+                                        fileName
+                                        url
+                                        description
+                                        width
+                                        height
+                                    }
+                                    seo {
+                                    title
+                                    excerpt
+                                    image {
+                                        fileName
+                                        url
+                                        description
+                                        width
+                                        height
+                                    }
+                                    keywords
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                seo {
+                    title
+                    excerpt
+                    image {
+                        fileName
+                        url
+                        description
+                        width
+                        height
+                    }
+                    keywords
+                }
+            }
+        }
+    }
+`
+
+export async function getLandingPageBySlug(
+  slug: string,
+): Promise<LandingPage | null> {
+  const response = await typedFetchGraphQL<{
+    landingPageCollection: { items: Array<LandingPage> }
+  }>(LandingPageBySlugQuery, { slug })
+
+  if (!response.data) {
+    console.error(`Error for Landing Page with slug:${slug}`, response.errors)
+
+    return null
+  }
+
+  const landingPage = response.data.landingPageCollection.items[0]
 
   return validateWithSchema(LandingPageSchema, landingPage)
 }

--- a/app/models/page.server.ts
+++ b/app/models/page.server.ts
@@ -9,7 +9,7 @@ export const PageSchema = z.object({
   title: z.string(),
   headline: z.string(),
   mainContent: RichTextSchema,
-  featuredImage: ImageSchema,
+  featuredImage: ImageSchema.nullable().optional(),
   seo: SEOSchema,
 })
 
@@ -94,7 +94,7 @@ export const PageBySlugQuery = `
 `
 export async function getPageBySlug(slug: string): Promise<Page | null> {
   const response = await typedFetchGraphQL<{
-    pageCollection: { items: Page[] }
+    pageCollection: { items: Array<Page> }
   }>(PageBySlugQuery, { slug })
 
   if (!response.data) {

--- a/app/models/team.server.ts
+++ b/app/models/team.server.ts
@@ -83,37 +83,25 @@ export async function getTeamPage(id: string) {
   return validateWithSchema(TeamPageSchema, teamPage)
 }
 
-// This function will crash the GraphQL server if the limit is too high
-export async function getTeamPages(count: number = 10) {
-  const query = `query {
-        teamPageCollection(limit: ${count}) {
-            items {
-                title
-                headline
-                sectionsCollection {
-                    items {
-                        title
-                        headline
-                        mainContent {
-                            json
-                        }
-                        teamMembersCollection(limit: 20) {
-                            items {
-                                slug
-                                name
-                                position
-                                department
-                                featuredImage {
-                                    fileName
-                                    url
-                                    description
-                                    width
-                                    height
-                                }
-                            }
-                        }
-                    }
-                }
+const TeamPageBySlugQuery = `
+  query TeamPageBySlug($slug: String!) {
+    teamPageCollection(where: { slug: $slug }, limit: 1) {
+      items {
+        title
+        headline
+        sectionsCollection {
+          items {
+            title
+            headline
+            mainContent {
+              json
+            }
+            teamMembersCollection(limit: 54) {
+              items {
+                slug
+                name
+                position
+                department
                 featuredImage {
                   fileName
                   url
@@ -121,33 +109,48 @@ export async function getTeamPages(count: number = 10) {
                   width
                   height
                 }
-                seo {
-                  title
-                  excerpt
-                  image {
-                    fileName
-                    url
-                    description
-                    width
-                    height
-                  }
-                  keywords
-                }
+              }
             }
+          }
         }
-    }`
+        featuredImage {
+          fileName
+          url
+          description
+          width
+          height
+        }
+        seo {
+          title
+          excerpt
+          image {
+            fileName
+            url
+            description
+            width
+            height
+          }
+          keywords
+        }
+      }
+    }
+  }
+`
 
+export async function getTeamPageBySlug(
+  slug: string,
+): Promise<TeamPage | null> {
   const response = await typedFetchGraphQL<{
     teamPageCollection: { items: Array<TeamPage> }
-  }>(query)
+  }>(TeamPageBySlugQuery, { slug })
 
   if (!response.data) {
-    console.error("Failed to fetch Team Pages", response.errors)
+    console.error("Failed to fetch team page", response.errors)
 
-    return []
+    return null
   }
 
-  const teamPages = response.data.teamPageCollection.items
+  const teamPage = response.data.teamPageCollection.items[0]
 
-  return validateWithSchema(TeamPagesSchema, teamPages)
+  return validateWithSchema(TeamPageSchema, teamPage)
 }

--- a/app/routes/$slug.tsx
+++ b/app/routes/$slug.tsx
@@ -128,6 +128,10 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 
   invariantResponse(slug, "Page slug not found.", { status: 404 })
 
+  const foundSlash = slug.indexOf("/") === 0
+
+  invariantResponse(!foundSlash, "Page slug not found.", { status: 404 })
+
   const contentType = await findContentBySlug(slug)
 
   invariantResponse(contentType, "Content not found.", { status: 404 })

--- a/app/routes/$slug.tsx
+++ b/app/routes/$slug.tsx
@@ -3,6 +3,7 @@ import { useLoaderData } from "@remix-run/react"
 import { z } from "zod"
 import { getAboutPageBySlug } from "~/models/about.server"
 import { getCaseStudiesPageBySlug } from "~/models/case-studies.server"
+import { getEPARegions } from "~/models/epa-region.server"
 import { getLandingPageBySlug } from "~/models/landing-page.server"
 import { getPageBySlug } from "~/models/page.server"
 import { getTeamPageBySlug } from "~/models/team.server"
@@ -172,8 +173,11 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
           status: 404,
         })
 
+        const regions = await getEPARegions()
+
         return json({
           landingPage,
+          regions,
           __typename: contentType.__typename,
         } as const)
       default:

--- a/app/routes/$slug.tsx
+++ b/app/routes/$slug.tsx
@@ -1,0 +1,221 @@
+import { json, type LoaderFunctionArgs } from "@remix-run/node"
+import { useLoaderData } from "@remix-run/react"
+import { z } from "zod"
+import { getAboutPageBySlug } from "~/models/about.server"
+import { getCaseStudiesPageBySlug } from "~/models/case-studies.server"
+import { getLandingPageBySlug } from "~/models/landing-page.server"
+import { getPageBySlug } from "~/models/page.server"
+import { getTeamPageBySlug } from "~/models/team.server"
+import { typedFetchGraphQL } from "~/services/contentful.server"
+import { AboutPage } from "~/ui/templates/AboutPage"
+import { CaseStudiesPage } from "~/ui/templates/CaseStudiesPage"
+import { LandingPage } from "~/ui/templates/LandingPage"
+import { Page } from "~/ui/templates/Page"
+import { TeamPage } from "~/ui/templates/TeamPage"
+import { invariantResponse } from "~/utils/invariant.server"
+
+// This query tries to find a page that doesn't have a designated route
+// This is for basic Page, TeamPage, CaseStudies, etc.
+const FindBySlugQuery = `
+    query FindBySlug($slug: String!) {
+        pageCollection(where: {slug: $slug}, limit: 1) {
+            items {
+                slug
+                __typename
+            }
+        }
+        teamPageCollection(where: {slug: $slug}, limit: 1) {
+            items {
+                slug
+                __typename
+            }
+        }
+        caseStudiesCollection(where: {slug: $slug}, limit: 1) {
+            items {
+                slug
+                __typename
+            }
+        }
+        aboutPageCollection(where: {slug: $slug}, limit: 1) {
+            items {
+                slug
+                __typename
+            }
+        }
+        landingPageCollection(where: {slug: $slug}, limit: 1) {
+            items {
+                slug
+                __typename
+            }
+        }
+    }
+`
+
+async function findContentBySlug(
+  slug: string,
+): Promise<{ __typename: string; slug: string } | null> {
+  const response = await typedFetchGraphQL<{
+    pageCollection: {
+      items: {
+        slug: string
+        __typename: string
+      }[]
+    }
+    teamPageCollection: {
+      items: {
+        slug: string
+        __typename: string
+      }[]
+    }
+    caseStudiesCollection: {
+      items: {
+        slug: string
+        __typename: string
+      }[]
+    }
+    aboutPageCollection: {
+      items: {
+        slug: string
+        __typename: string
+      }[]
+    }
+    landingPageCollection: {
+      items: {
+        slug: string
+        __typename: string
+      }[]
+    }
+  }>(FindBySlugQuery, { slug })
+
+  if (!response.data) {
+    console.error(`Error for page with slug: ${slug}`, response.errors)
+
+    return null
+  }
+
+  const page = response.data.pageCollection.items[0]
+  const teamPage = response.data.teamPageCollection.items[0]
+  const caseStudiesPage = response.data.caseStudiesCollection.items[0]
+  const aboutPage = response.data.aboutPageCollection.items[0]
+  const landingPage = response.data.landingPageCollection.items[0]
+
+  if (page) {
+    return page
+  }
+
+  if (teamPage) {
+    return teamPage
+  }
+
+  if (caseStudiesPage) {
+    return caseStudiesPage
+  }
+
+  if (aboutPage) {
+    return aboutPage
+  }
+
+  if (landingPage) {
+    return landingPage
+  }
+
+  return null
+}
+
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+  const { slug } = params
+
+  invariantResponse(slug, "Page slug not found.", { status: 404 })
+
+  const contentType = await findContentBySlug(slug)
+
+  invariantResponse(contentType, "Content not found.", { status: 404 })
+
+  try {
+    switch (contentType.__typename) {
+      case "Page":
+        const page = await getPageBySlug(slug)
+
+        invariantResponse(page, "Page not found", { status: 404 })
+
+        return json({ page, __typename: contentType.__typename } as const)
+      case "TeamPage":
+        const teamPage = await getTeamPageBySlug(slug)
+
+        invariantResponse(teamPage, "Team page not found", { status: 404 })
+
+        return json({ teamPage, __typename: contentType.__typename } as const)
+      case "CaseStudies":
+        const caseStudiesPage = await getCaseStudiesPageBySlug(slug)
+
+        invariantResponse(caseStudiesPage, "Case studies page not found", {
+          status: 404,
+        })
+
+        return json({
+          caseStudiesPage,
+          __typename: contentType.__typename,
+        } as const)
+      case "AboutPage":
+        const aboutPage = await getAboutPageBySlug(slug)
+
+        invariantResponse(aboutPage, "About page not found", { status: 404 })
+
+        return json({
+          aboutPage,
+          __typename: contentType.__typename,
+        } as const)
+      case "LandingPage":
+        const landingPage = await getLandingPageBySlug(slug)
+
+        invariantResponse(landingPage, "Landing page not found", {
+          status: 404,
+        })
+
+        return json({
+          landingPage,
+          __typename: contentType.__typename,
+        } as const)
+      default:
+        // Just throw an error if we can't find the page
+        invariantResponse(false, "Page not found", { status: 404 })
+    }
+  } catch (error) {
+    // Log this on the server
+    console.error(error)
+
+    if (error instanceof Response) {
+      const message = await error.text()
+
+      throw new Response(message, { status: 404 })
+    }
+
+    if (error instanceof z.ZodError) {
+      const errors = error.issues.map((error) => error.message)
+      const errorMessage = errors.join(", ")
+
+      throw new Response(errorMessage, { status: 404 })
+    }
+
+    throw new Response("Something went wrong!", { status: 500 })
+  }
+}
+
+export default function Slug() {
+  const data = useLoaderData<typeof loader>()
+
+  switch (data.__typename) {
+    case "Page":
+      return <Page {...data.page} />
+    case "TeamPage":
+      return <TeamPage {...data.teamPage} />
+    case "CaseStudies":
+      return <CaseStudiesPage {...data.caseStudiesPage} />
+    case "AboutPage":
+      return <AboutPage {...data.aboutPage} />
+    case "LandingPage":
+      return <LandingPage {...data.landingPage} />
+    default:
+      return null
+  }
+}

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -47,11 +47,5 @@ export const meta: MetaFunction<typeof loader, { root: RootLoader }> = ({
 export default function _index() {
   const { landingPage } = useLoaderData<typeof loader>()
 
-  return (
-    <LandingPage
-      title={landingPage.title}
-      sectionsCollection={landingPage.sectionsCollection}
-      seo={landingPage.seo}
-    />
-  )
+  return <LandingPage {...landingPage} />
 }

--- a/app/schemas/contentful-fields/rich-text.server.ts
+++ b/app/schemas/contentful-fields/rich-text.server.ts
@@ -85,9 +85,7 @@ export const LinksSchema = z.object({
   }),
 })
 
-export function createRichTextSchemaWithEmbeddedAssets<T>(
-  schema: z.Schema<T>,
-) {
+export function createRichTextSchemaWithEmbeddedAssets<T>(schema: z.Schema<T>) {
   return RichTextSchema.and(schema)
 }
 

--- a/app/ui/templates/Page.tsx
+++ b/app/ui/templates/Page.tsx
@@ -2,7 +2,12 @@ import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 import { type Page } from "~/models/page.server"
 import Header from "~/ui/components/Header"
 import { motion, useReducedMotion } from "framer-motion"
-import { BLOCKS, type Block, INLINES, type Inline } from "@contentful/rich-text-types"
+import {
+  BLOCKS,
+  type Block,
+  INLINES,
+  type Inline,
+} from "@contentful/rich-text-types"
 import { type ReactNode } from "react"
 
 type PageProps = Page
@@ -28,6 +33,43 @@ const richTextRenderOptions = {
     },
     [BLOCKS.HEADING_2]: (node: Block | Inline, children: ReactNode) => {
       return <h2 className="mb-5 text-3xl">{children}</h2>
+    },
+    [BLOCKS.HEADING_3]: (node: Block | Inline, children: ReactNode) => {
+      return (
+        <h3 className="mb-4 text-2xl font-bold dark:text-gray-200">
+          {children}
+        </h3>
+      )
+    },
+    [BLOCKS.HEADING_4]: (node: Block | Inline, children: ReactNode) => {
+      return (
+        <h4 className="mb-4 text-xl uppercase dark:text-gray-200">
+          {children}
+        </h4>
+      )
+    },
+    [BLOCKS.HEADING_5]: (node: Block | Inline, children: ReactNode) => {
+      return (
+        <h5 className="mb-4 text-lg font-bold dark:text-gray-200">
+          {children}
+        </h5>
+      )
+    },
+    [BLOCKS.HEADING_6]: (node: Block | Inline, children: ReactNode) => {
+      return (
+        <h6 className="text-md mb-4 font-bold uppercase dark:text-gray-200">
+          {children}
+        </h6>
+      )
+    },
+    [BLOCKS.UL_LIST]: (node: Block | Inline, children: ReactNode) => {
+      return <ul className="ml-12 list-disc">{children}</ul>
+    },
+    [BLOCKS.OL_LIST]: (node: Block | Inline, children: ReactNode) => {
+      return <ol className="ml-12 list-decimal">{children}</ol>
+    },
+    [BLOCKS.LIST_ITEM]: (node: Block | Inline, children: ReactNode) => {
+      return <li>{children}</li>
     },
   },
 }
@@ -96,7 +138,7 @@ export function Page({
               ></motion.div>
             </div>
             <div className="text-darkBlue md:order-1 md:w-2/3">
-              <h1 className="mb-5 text-3xl font-bold">{headline}</h1>
+              <h1 className="mb-5 text-4xl font-bold">{headline}</h1>
               {documentToReactComponents(
                 mainContent.json,
                 richTextRenderOptions,

--- a/app/ui/templates/Page.tsx
+++ b/app/ui/templates/Page.tsx
@@ -9,6 +9,7 @@ import {
   type Inline,
 } from "@contentful/rich-text-types"
 import { type ReactNode } from "react"
+import { cn } from "~/lib/utils"
 
 type PageProps = Page
 
@@ -82,62 +83,72 @@ export function Page({
 }: PageProps) {
   const prefersReducedMotion = useReducedMotion()
 
-  const { url, description, width, height } = featuredImage
-
   return (
     <>
       <Header />
       <main>
-        <div className="mx-auto max-w-screen-xl px-6 py-12 md:px-5">
+        <div
+          className={cn(
+            "mx-auto max-w-screen-xl px-6 py-12 md:px-5",
+            !featuredImage ? "md:max-w-screen-lg" : "",
+          )}
+        >
           <div className="flex flex-col items-center gap-12 md:flex-row">
-            <div className="relative my-12 md:order-2 md:w-1/3">
-              <motion.img
-                initial={{
-                  opacity: prefersReducedMotion ? 1 : 0,
-                  transform: prefersReducedMotion ? "scale(1)" : "scale(0)",
-                }}
-                whileInView={{ opacity: 1, transform: "scale(1)" }}
-                viewport={{ once: true }}
-                transition={{
-                  ease: "linear",
-                  duration: 0.5,
-                }}
-                className="relative z-10 aspect-square w-full rounded-full object-cover"
-                src={url}
-                alt={description || ""}
-                width={width}
-                height={height}
-              />
-              <motion.div
-                initial={{
-                  opacity: prefersReducedMotion ? 1 : 0,
-                  transform: prefersReducedMotion ? "scale(1)" : "scale(0)",
-                }}
-                whileInView={{ opacity: 1, transform: "scale(1)" }}
-                viewport={{ once: true }}
-                transition={{
-                  ease: "linear",
-                  duration: 0.5,
-                  delay: 0.25,
-                }}
-                className="absolute right-0 top-[-3rem] h-[156px] w-[156px] rounded-full bg-blue"
-              ></motion.div>
-              <motion.div
-                initial={{
-                  opacity: prefersReducedMotion ? 1 : 0,
-                  transform: prefersReducedMotion ? "scale(1)" : "scale(0)",
-                }}
-                whileInView={{ opacity: 1, transform: "scale(1)" }}
-                viewport={{ once: true }}
-                transition={{
-                  ease: "linear",
-                  duration: 0.5,
-                  delay: 0.5,
-                }}
-                className="absolute bottom-[-3rem] left-[5rem] h-[156px] w-[156px] rounded-full bg-lightGreen"
-              ></motion.div>
-            </div>
-            <div className="text-darkBlue md:order-1 md:w-2/3">
+            {featuredImage ? (
+              <div className="relative my-12 md:order-2 md:w-1/3">
+                <motion.img
+                  initial={{
+                    opacity: prefersReducedMotion ? 1 : 0,
+                    transform: prefersReducedMotion ? "scale(1)" : "scale(0)",
+                  }}
+                  whileInView={{ opacity: 1, transform: "scale(1)" }}
+                  viewport={{ once: true }}
+                  transition={{
+                    ease: "linear",
+                    duration: 0.5,
+                  }}
+                  className="relative z-10 aspect-square w-full rounded-full object-cover"
+                  src={featuredImage.url}
+                  alt={featuredImage.description || ""}
+                  width={featuredImage.width}
+                  height={featuredImage.height}
+                />
+                <motion.div
+                  initial={{
+                    opacity: prefersReducedMotion ? 1 : 0,
+                    transform: prefersReducedMotion ? "scale(1)" : "scale(0)",
+                  }}
+                  whileInView={{ opacity: 1, transform: "scale(1)" }}
+                  viewport={{ once: true }}
+                  transition={{
+                    ease: "linear",
+                    duration: 0.5,
+                    delay: 0.25,
+                  }}
+                  className="absolute right-0 top-[-3rem] h-[156px] w-[156px] rounded-full bg-blue"
+                ></motion.div>
+                <motion.div
+                  initial={{
+                    opacity: prefersReducedMotion ? 1 : 0,
+                    transform: prefersReducedMotion ? "scale(1)" : "scale(0)",
+                  }}
+                  whileInView={{ opacity: 1, transform: "scale(1)" }}
+                  viewport={{ once: true }}
+                  transition={{
+                    ease: "linear",
+                    duration: 0.5,
+                    delay: 0.5,
+                  }}
+                  className="absolute bottom-[-3rem] left-[5rem] h-[156px] w-[156px] rounded-full bg-lightGreen"
+                ></motion.div>
+              </div>
+            ) : null}
+            <div
+              className={cn(
+                "text-darkBlue md:order-1 md:w-2/3",
+                !featuredImage ? "md:w-full" : "",
+              )}
+            >
               <h1 className="mb-5 text-4xl font-bold">{headline}</h1>
               {documentToReactComponents(
                 mainContent.json,

--- a/app/ui/templates/Page.tsx
+++ b/app/ui/templates/Page.tsx
@@ -1,82 +1,20 @@
-import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
+import {
+  type Options,
+  documentToReactComponents,
+} from "@contentful/rich-text-react-renderer"
 import { type Page } from "~/models/page.server"
 import Header from "~/ui/components/Header"
 import { motion, useReducedMotion } from "framer-motion"
-import {
-  BLOCKS,
-  type Block,
-  INLINES,
-  type Inline,
-} from "@contentful/rich-text-types"
-import { type ReactNode } from "react"
 import { cn } from "~/lib/utils"
+import { defaultRichTextRenderOptions } from "~/utils/rich-text-render-options"
 
 type PageProps = Page
 
-const richTextRenderOptions = {
-  renderNode: {
-    [INLINES.HYPERLINK]: (node: Block | Inline, children: ReactNode) => {
-      const { data } = node
-      const { uri } = data
-      return (
-        <a
-          className="text-primary underline dark:text-gray-400"
-          target="_blank"
-          rel="noreferrer"
-          href={uri}
-        >
-          {children}
-        </a>
-      )
-    },
-    [BLOCKS.PARAGRAPH]: (node: Block | Inline, children: ReactNode) => {
-      return <p className="mb-4 text-base leading-relaxed">{children}</p>
-    },
-    [BLOCKS.HEADING_2]: (node: Block | Inline, children: ReactNode) => {
-      return <h2 className="mb-5 text-3xl">{children}</h2>
-    },
-    [BLOCKS.HEADING_3]: (node: Block | Inline, children: ReactNode) => {
-      return (
-        <h3 className="mb-4 text-2xl font-bold dark:text-gray-200">
-          {children}
-        </h3>
-      )
-    },
-    [BLOCKS.HEADING_4]: (node: Block | Inline, children: ReactNode) => {
-      return (
-        <h4 className="mb-4 text-xl uppercase dark:text-gray-200">
-          {children}
-        </h4>
-      )
-    },
-    [BLOCKS.HEADING_5]: (node: Block | Inline, children: ReactNode) => {
-      return (
-        <h5 className="mb-4 text-lg font-bold dark:text-gray-200">
-          {children}
-        </h5>
-      )
-    },
-    [BLOCKS.HEADING_6]: (node: Block | Inline, children: ReactNode) => {
-      return (
-        <h6 className="text-md mb-4 font-bold uppercase dark:text-gray-200">
-          {children}
-        </h6>
-      )
-    },
-    [BLOCKS.UL_LIST]: (node: Block | Inline, children: ReactNode) => {
-      return <ul className="ml-12 list-disc">{children}</ul>
-    },
-    [BLOCKS.OL_LIST]: (node: Block | Inline, children: ReactNode) => {
-      return <ol className="ml-12 list-decimal">{children}</ol>
-    },
-    [BLOCKS.LIST_ITEM]: (node: Block | Inline, children: ReactNode) => {
-      return <li>{children}</li>
-    },
-  },
+const richTextRenderOptions: Options = {
+  ...defaultRichTextRenderOptions,
 }
 
 export function Page({
-  title,
   headline,
   mainContent,
   featuredImage,

--- a/app/utils/rich-text-render-options.tsx
+++ b/app/utils/rich-text-render-options.tsx
@@ -1,0 +1,77 @@
+import { type Options } from "@contentful/rich-text-react-renderer"
+import {
+  BLOCKS,
+  type Block,
+  INLINES,
+  type Inline,
+} from "@contentful/rich-text-types"
+import { type ReactNode } from "react"
+
+export const defaultRichTextRenderOptions: Options = {
+  renderNode: {
+    [INLINES.HYPERLINK]: (node: Block | Inline, children: ReactNode) => {
+      const { data } = node
+      const { uri } = data
+      return (
+        <a
+          className="text-primary underline dark:text-gray-400"
+          target="_blank"
+          rel="noreferrer"
+          href={uri}
+        >
+          {children}
+        </a>
+      )
+    },
+    [BLOCKS.PARAGRAPH]: (node: Block | Inline, children: ReactNode) => {
+      return <p className="mb-4 text-base leading-relaxed">{children}</p>
+    },
+    [BLOCKS.HEADING_2]: (node: Block | Inline, children: ReactNode) => {
+      return <h2 className="mb-5 text-3xl">{children}</h2>
+    },
+    [BLOCKS.HEADING_3]: (node: Block | Inline, children: ReactNode) => {
+      return (
+        <h3 className="mb-4 text-2xl font-bold dark:text-gray-200">
+          {children}
+        </h3>
+      )
+    },
+    [BLOCKS.HEADING_4]: (node: Block | Inline, children: ReactNode) => {
+      return (
+        <h4 className="mb-4 text-xl uppercase dark:text-gray-200">
+          {children}
+        </h4>
+      )
+    },
+    [BLOCKS.HEADING_5]: (node: Block | Inline, children: ReactNode) => {
+      return (
+        <h5 className="mb-4 text-lg font-bold dark:text-gray-200">
+          {children}
+        </h5>
+      )
+    },
+    [BLOCKS.HEADING_6]: (node: Block | Inline, children: ReactNode) => {
+      return (
+        <h6 className="text-md mb-4 font-bold uppercase dark:text-gray-200">
+          {children}
+        </h6>
+      )
+    },
+    [BLOCKS.UL_LIST]: (node: Block | Inline, children: ReactNode) => {
+      return <ul className="ml-12 list-disc">{children}</ul>
+    },
+    [BLOCKS.OL_LIST]: (node: Block | Inline, children: ReactNode) => {
+      return <ol className="ml-12 list-decimal">{children}</ol>
+    },
+    [BLOCKS.LIST_ITEM]: (node: Block | Inline, children: ReactNode) => {
+      return <li>{children}</li>
+    },
+  },
+  renderText: (text: string) => {
+    return text
+      .split("\n")
+      .reduce<Array<ReactNode>>((children, textSegment, index) => {
+        return [...children, index > 0 && <br key={index} />, textSegment]
+      }, [])
+  },
+}


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Styling adjustments to `Page.tsx` to handle different headings and list items
- Styling adjustment to `Page.tsx` to handle when there _isn't_ a featured image for the page (the `featureImage` field in Contentful is optional)
- Initial logic to handle path/routes for pages that aren't static routes
     - For now we're handling the following content types:
        1. Page
        2. TeamPage
        3. CaseStudies
        4. LandingPage
        5. AboutPage 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Below are the instructions to test the updates of this pull request

1. Connect to the `master` environment in Contentful by updating your `.env` variables
6. Ensure all top level nav (and footer) nav items work as expected
7. Then locally visit the following URLs:
    - `/corporate-governance-non-profit-and-tax-legal-services-rfp-q-and-a`
    - `/general-legal-services-rfp-q-and-a`
    - `/epa-and-regulatory-legal-services-rfp-q-and-a`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
