### PR TITLE
Fix dropdown nav

### DIFF
--- a/app/ui/components/HeaderNavMenu.tsx
+++ b/app/ui/components/HeaderNavMenu.tsx
@@ -32,13 +32,15 @@ function HeaderNavMenuItem({
 
 type HeaderNavMenuSubMenuToggleButtonProps = ComponentPropsWithoutRef<"button">
 
-function HeaderNavMenuSubMenuToggleButton({
-  children,
-  className,
-  ...restOfProps
-}: HeaderNavMenuSubMenuToggleButtonProps) {
+const HeaderNavMenuSubMenuToggleButton = forwardRef<
+  // the type of element that will be assigned the ref
+  HTMLButtonElement,
+  // props that will be passed in
+  HeaderNavMenuSubMenuToggleButtonProps
+>(({ children, className, ...restOfProps }, ref) => {
   return (
     <button
+      ref={ref}
       className={cn(
         "flex w-full items-center justify-between gap-4 text-green after:text-xl after:transition-all after:ease-in-out after:content-['+'] hover:text-blue md:block md:after:content-[none]",
         className,
@@ -48,7 +50,7 @@ function HeaderNavMenuSubMenuToggleButton({
       {children}
     </button>
   )
-}
+})
 
 type HeaderNavMenuSubMenuProps = ComponentPropsWithoutRef<"ul">
 


### PR DESCRIPTION
# Description

The following updates have been made: 

- Resolve CSS bug on desktop to ensure _only_ last nav items in header menu who their submenu as `right: 0`
- Resolve bug where you could open multiple submenus and they would overlap 
  - Now you can only open one nav item's dropdown one at a time 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Connect to staging and notice that `Case Study` and `About Us` are nav items with submenus. Click around on both of them and click outside of them and the most recent open dropdown should close.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
